### PR TITLE
Improve init model check

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -75,4 +75,22 @@ def mock_ollama_responses(
         with urlopen(req):
             pass
 
+    # also stub /api/show so initialization succeeds
+    show_mapping = {
+        "request": {"method": "POST", "urlPath": "/api/show"},
+        "response": {
+            "status": 200,
+            "jsonBody": {"model_info": {"num_ctx": 8192}},
+            "headers": {"Content-Type": "application/json"},
+        },
+    }
+    req = Request(
+        f"{WIREMOCK_BASE_URL.rstrip('/')}/__admin/mappings",
+        data=json.dumps(show_mapping).encode(),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urlopen(req):
+        pass
+
     return scenario


### PR DESCRIPTION
## Summary
- validate model availability during initialization
- stub `/api/show` in test helpers
- ensure initialization fails clearly when model is missing

## Testing
- `make fmt`
- `make lint`
- `java -jar /tmp/wiremock.jar >/tmp/wiremock.log 2>&1 &`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6865b6cb1b60832584bf5cc1669024b8